### PR TITLE
FIFO reset

### DIFF
--- a/rtl/axis_fifo.v
+++ b/rtl/axis_fifo.v
@@ -176,7 +176,7 @@ reg overflow_reg = 1'b0, overflow_next;
 reg bad_frame_reg = 1'b0, bad_frame_next;
 reg good_frame_reg = 1'b0, good_frame_next;
 
-assign s_axis_tready = FRAME_FIFO ? (!full_cur || full_wr || DROP_WHEN_FULL) : !full;
+assign s_axis_tready = rst ? 1'b0 : (FRAME_FIFO ? (!full_cur || full_wr || DROP_WHEN_FULL) : !full);
 
 generate
     assign s_axis[DATA_WIDTH-1:0] = s_axis_tdata;

--- a/rtl/axis_fifo.v
+++ b/rtl/axis_fifo.v
@@ -251,7 +251,7 @@ always @(posedge clk) begin
     if (rst) begin
         wr_ptr_reg <= {ADDR_WIDTH+1{1'b0}};
         wr_ptr_cur_reg <= {ADDR_WIDTH+1{1'b0}};
-
+        wr_addr_reg <= {ADDR_WIDTH+1{1'b0}};
         drop_frame_reg <= 1'b0;
         overflow_reg <= 1'b0;
         bad_frame_reg <= 1'b0;
@@ -264,12 +264,12 @@ always @(posedge clk) begin
         overflow_reg <= overflow_next;
         bad_frame_reg <= bad_frame_next;
         good_frame_reg <= good_frame_next;
-    end
 
-    if (FRAME_FIFO) begin
+        if (FRAME_FIFO) begin
         wr_addr_reg <= wr_ptr_cur_next;
-    end else begin
-        wr_addr_reg <= wr_ptr_next;
+        end else begin
+            wr_addr_reg <= wr_ptr_next;
+        end
     end
 
     if (write) begin
@@ -302,13 +302,13 @@ end
 always @(posedge clk) begin
     if (rst) begin
         rd_ptr_reg <= {ADDR_WIDTH+1{1'b0}};
+        rd_addr_reg <= {ADDR_WIDTH+1{1'b0}};
         mem_read_data_valid_reg <= 1'b0;
     end else begin
         rd_ptr_reg <= rd_ptr_next;
+        rd_addr_reg <= rd_ptr_next;
         mem_read_data_valid_reg <= mem_read_data_valid_next;
     end
-
-    rd_addr_reg <= rd_ptr_next;
 
     if (read) begin
         mem_read_data_reg <= mem[rd_addr_reg[ADDR_WIDTH-1:0]];

--- a/rtl/axis_fifo.v
+++ b/rtl/axis_fifo.v
@@ -266,7 +266,7 @@ always @(posedge clk) begin
         good_frame_reg <= good_frame_next;
 
         if (FRAME_FIFO) begin
-        wr_addr_reg <= wr_ptr_cur_next;
+            wr_addr_reg <= wr_ptr_cur_next;
         end else begin
             wr_addr_reg <= wr_ptr_next;
         end

--- a/tb/test_axis_fifo.py
+++ b/tb/test_axis_fifo.py
@@ -62,7 +62,7 @@ def bench():
 
     # Inputs
     clk = Signal(bool(0))
-    rst = Signal(bool(0))
+    rst_dut = Signal(bool(0))
     current_test = Signal(intbv(0)[8:])
 
     s_axis_tdata = Signal(intbv(0)[DATA_WIDTH:])
@@ -85,6 +85,7 @@ def bench():
     m_axis_tuser = Signal(intbv(0)[USER_WIDTH:])
 
     # sources and sinks
+    rst_tb = Signal(bool(0))
     source_pause = Signal(bool(0))
     sink_pause = Signal(bool(0))
 
@@ -92,7 +93,7 @@ def bench():
 
     source_logic = source.create_logic(
         clk,
-        rst,
+        rst_tb,
         tdata=s_axis_tdata,
         tkeep=s_axis_tkeep,
         tvalid=s_axis_tvalid,
@@ -109,7 +110,7 @@ def bench():
 
     sink_logic = sink.create_logic(
         clk,
-        rst,
+        rst_tb,
         tdata=m_axis_tdata,
         tkeep=m_axis_tkeep,
         tvalid=m_axis_tvalid,
@@ -129,7 +130,7 @@ def bench():
     dut = Cosimulation(
         "vvp -m myhdl %s.vvp -lxt2" % testbench,
         clk=clk,
-        rst=rst,
+        rst=rst_dut,
         current_test=current_test,
 
         s_axis_tdata=s_axis_tdata,
@@ -159,9 +160,11 @@ def bench():
     def check():
         yield delay(100)
         yield clk.posedge
-        rst.next = 1
+        rst_dut.next = 1
+        rst_tb.next = 1
         yield clk.posedge
-        rst.next = 0
+        rst_dut.next = 0
+        rst_tb.next = 0
         yield clk.posedge
         yield delay(100)
         yield clk.posedge
@@ -441,9 +444,11 @@ def bench():
         yield clk.posedge
         yield clk.posedge
 
-        rst.next = 1
+        rst_dut.next = 1
+        rst_tb.next = 1
         yield clk.posedge
-        rst.next = 0
+        rst_dut.next = 0
+        rst_tb.next = 0
 
         sink_pause.next = 0
 
@@ -507,6 +512,53 @@ def bench():
             rx_frame = sink.recv()
 
             assert rx_frame == test_frame
+
+        yield delay(100)
+
+        yield clk.posedge
+        print("test 12: reset")
+        current_test.next = 12
+
+        # send data without reading it
+        sink_pause.next = 1
+
+        test_frame = axis_ep.AXIStreamFrame(
+            b'\x80\x00',
+            id=1,
+            dest=1
+        )
+
+        source.send(test_frame)
+
+        yield delay(100)
+
+        # prepare second frame, but don't send it yet
+        test_frame = axis_ep.AXIStreamFrame(
+            b'\xAA\xBB',
+            id=2,
+            dest=2
+        )
+
+        source_pause.next = 1
+
+        source.send(test_frame)
+
+        # reset the FIFO
+        yield clk.posedge
+        rst_dut.next = 1
+
+        # start tranmission immediately after reset
+        source_pause.next = 0
+        yield clk.posedge
+        rst_dut.next = 0
+
+        # receive test frame
+        sink_pause.next = 0
+
+        yield sink.wait()
+        rx_frame = sink.recv()
+
+        assert rx_frame == test_frame
 
         yield delay(100)
 

--- a/tb/test_axis_fifo_64.py
+++ b/tb/test_axis_fifo_64.py
@@ -516,8 +516,44 @@ def bench():
         yield delay(100)
 
         yield clk.posedge
-        print("test 12: reset")
+        print("test 12: reset status")
         current_test.next = 12
+
+        # send data without reading it
+        sink_pause.next = 1
+
+        test_frame = axis_ep.AXIStreamFrame(
+            b'\xDA\xD1\xD2\xD3\xD4\xD5' +
+            b'\x5A\x51\x52\x53\x54\x55' +
+            b'\x80\x00',
+            id=1,
+            dest=1
+        )
+
+        source.send(test_frame)
+
+        yield delay(100)
+        yield clk.posedge
+
+        # there should be data available on the master side
+        assert m_axis_tvalid == 1
+
+        # reset the FIFO
+        rst_dut.next = 1
+        yield clk.posedge
+
+        # don't signal ready while in reset
+        assert s_axis_tready == 0
+
+        rst_dut.next = 0
+        yield clk.posedge
+
+        assert m_axis_tvalid == 0
+
+        yield delay(100)
+        yield clk.posedge
+        print("test 13: write after reset")
+        current_test.next = 13
 
         # send data without reading it
         sink_pause.next = 1

--- a/tb/test_axis_fifo_64.py
+++ b/tb/test_axis_fifo_64.py
@@ -514,11 +514,11 @@ def bench():
             assert rx_frame == test_frame
 
         yield delay(100)
-        
+
         yield clk.posedge
         print("test 12: reset")
         current_test.next = 12
-        
+
         # send data without reading it
         sink_pause.next = 1
 


### PR DESCRIPTION
I ran into an issue where the FIFO was reset and data became available the cycle after. The FIFO axis-slave hast tready asserted, but the internal write address is not correct in that case.
One solution might be to deassert tready for the cycle after the reset. Alternatively the address calculation can provide the correct address immediately after reset. This implements the latter.
Also I think the tready signal should be deasserted during reset. The core is definitely not going to be ready to receive data and hence should signal accordingly.
I prepared test cases for these fixes and added them to the test bench.
