### PR TITLE
Rename arbiter module to verilog_axis_arbiter

### DIFF
--- a/rtl/arbiter.v
+++ b/rtl/arbiter.v
@@ -31,7 +31,7 @@ THE SOFTWARE.
 /*
  * Arbiter module
  */
-module arbiter #
+module verilog_axis_arbiter #
 (
     parameter PORTS = 4,
     // select round robin arbitration

--- a/rtl/axis_arb_mux.v
+++ b/rtl/axis_arb_mux.v
@@ -151,7 +151,7 @@ wire [DEST_WIDTH-1:0] current_s_tdest  = s_axis_tdest_reg[grant_encoded*DEST_WID
 wire [USER_WIDTH-1:0] current_s_tuser  = s_axis_tuser_reg[grant_encoded*USER_WIDTH +: USER_WIDTH];
 
 // arbiter instance
-arbiter #(
+verilog_axis_arbiter #(
     .PORTS(S_COUNT),
     .ARB_TYPE_ROUND_ROBIN(ARB_TYPE_ROUND_ROBIN),
     .ARB_BLOCK(1),

--- a/rtl/axis_ram_switch.v
+++ b/rtl/axis_ram_switch.v
@@ -284,7 +284,7 @@ generate
 
 if (S_COUNT > 1) begin
 
-    arbiter #(
+    verilog_axis_arbiter #(
         .PORTS(S_COUNT),
         .ARB_TYPE_ROUND_ROBIN(1),
         .ARB_BLOCK(0),
@@ -320,7 +320,7 @@ generate
 
 if (M_COUNT > 1) begin
 
-    arbiter #(
+    verilog_axis_arbiter #(
         .PORTS(M_COUNT),
         .ARB_TYPE_ROUND_ROBIN(1),
         .ARB_BLOCK(0),
@@ -504,7 +504,7 @@ generate
         wire grant_valid;
         wire [CL_M_COUNT-1:0] grant_encoded;
 
-        arbiter #(
+        verilog_axis_arbiter #(
             .PORTS(M_COUNT),
             .ARB_TYPE_ROUND_ROBIN(ARB_TYPE_ROUND_ROBIN),
             .ARB_BLOCK(1),
@@ -824,7 +824,7 @@ generate
         wire grant_valid;
         wire [CL_S_COUNT-1:0] grant_encoded;
 
-        arbiter #(
+        verilog_axis_arbiter #(
             .PORTS(S_COUNT),
             .ARB_TYPE_ROUND_ROBIN(ARB_TYPE_ROUND_ROBIN),
             .ARB_BLOCK(1),

--- a/rtl/axis_switch.v
+++ b/rtl/axis_switch.v
@@ -318,7 +318,7 @@ generate
         wire grant_valid;
         wire [CL_S_COUNT-1:0] grant_encoded;
 
-        arbiter #(
+        verilog_axis_arbiter #(
             .PORTS(S_COUNT),
             .ARB_TYPE_ROUND_ROBIN(ARB_TYPE_ROUND_ROBIN),
             .ARB_BLOCK(1),

--- a/tb/test_arbiter.v
+++ b/tb/test_arbiter.v
@@ -71,7 +71,7 @@ initial begin
     $dumpvars(0, test_arbiter);
 end
 
-arbiter #(
+verilog_axis_arbiter #(
     .PORTS(PORTS),
     .ARB_TYPE_ROUND_ROBIN(ARB_TYPE_ROUND_ROBIN),
     .ARB_BLOCK(ARB_BLOCK),

--- a/tb/test_arbiter_rr.v
+++ b/tb/test_arbiter_rr.v
@@ -71,7 +71,7 @@ initial begin
     $dumpvars(0, test_arbiter_rr);
 end
 
-arbiter #(
+verilog_axis_arbiter #(
     .PORTS(PORTS),
     .ARB_TYPE_ROUND_ROBIN(ARB_TYPE_ROUND_ROBIN),
     .ARB_BLOCK(ARB_BLOCK),


### PR DESCRIPTION
arbiter is a reasonably common module name. Avoid namespace collisions by prefixing it with verilog_axis_
