### PR TITLE
Add explicit python3 prefix to all python paths in test suite

### DIFF
--- a/tb/axis_arb_mux/Makefile
+++ b/tb/axis_arb_mux/Makefile
@@ -75,7 +75,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(PORTS)
+	python3 $< -p $(PORTS)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/axis_arb_mux/test_axis_arb_mux.py
+++ b/tb/axis_arb_mux/test_axis_arb_mux.py
@@ -329,7 +329,7 @@ def test_axis_arb_mux(request, ports, data_width, round_robin):
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
             cwd=tests_dir
         ).wait()
 

--- a/tb/axis_broadcast/Makefile
+++ b/tb/axis_broadcast/Makefile
@@ -69,7 +69,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(PORTS)
+	python3 $< -p $(PORTS)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/axis_broadcast/test_axis_broadcast.py
+++ b/tb/axis_broadcast/test_axis_broadcast.py
@@ -157,7 +157,7 @@ def test_axis_broadcast(request, ports, data_width):
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
             cwd=tests_dir
         ).wait()
 

--- a/tb/axis_demux/Makefile
+++ b/tb/axis_demux/Makefile
@@ -70,7 +70,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(PORTS)
+	python3 $< -p $(PORTS)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/axis_demux/test_axis_demux.py
+++ b/tb/axis_demux/test_axis_demux.py
@@ -173,7 +173,7 @@ def test_axis_demux(request, ports, data_width, tdest_route):
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
             cwd=tests_dir
         ).wait()
 

--- a/tb/axis_mux/Makefile
+++ b/tb/axis_mux/Makefile
@@ -68,7 +68,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(PORTS)
+	python3 $< -p $(PORTS)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/axis_mux/test_axis_mux.py
+++ b/tb/axis_mux/test_axis_mux.py
@@ -193,7 +193,7 @@ def test_axis_mux(request, ports, data_width):
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{ports}"],
             cwd=tests_dir
         ).wait()
 

--- a/tb/axis_ram_switch/Makefile
+++ b/tb/axis_ram_switch/Makefile
@@ -87,7 +87,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(S_COUNT) $(M_COUNT)
+	python3 $< -p $(S_COUNT) $(M_COUNT)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/axis_ram_switch/test_axis_ram_switch.py
+++ b/tb/axis_ram_switch/test_axis_ram_switch.py
@@ -337,7 +337,7 @@ def test_axis_ram_switch(request, s_count, m_count, s_data_width, m_data_width):
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{s_count}", f"{m_count}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{s_count}", f"{m_count}"],
             cwd=tests_dir
         ).wait()
 

--- a/tb/axis_switch/Makefile
+++ b/tb/axis_switch/Makefile
@@ -78,7 +78,7 @@ endif
 include $(shell cocotb-config --makefiles)/Makefile.sim
 
 $(WRAPPER).v: ../../rtl/$(DUT)_wrap.py
-	$< -p $(S_COUNT) $(M_COUNT)
+	python3 $< -p $(S_COUNT) $(M_COUNT)
 
 iverilog_dump.v:
 	echo 'module iverilog_dump();' > $@

--- a/tb/axis_switch/test_axis_switch.py
+++ b/tb/axis_switch/test_axis_switch.py
@@ -335,7 +335,7 @@ def test_axis_switch(request, s_count, m_count, data_width):
     wrapper_file = os.path.join(tests_dir, f"{wrapper}.v")
     if not os.path.exists(wrapper_file):
         subprocess.Popen(
-            [os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{s_count}", f"{m_count}"],
+            ["python3", os.path.join(rtl_dir, f"{dut}_wrap.py"), "-p", f"{s_count}", f"{m_count}"],
             cwd=tests_dir
         ).wait()
 


### PR DESCRIPTION
Allows WSL to properly execute the tests by explicitly stating how the python files should execute. Line ending issues cause WSL to get confused if the repo uses Windows line endings.