### PR TITLE
Fix set_bus_skew constraint upper bound in axis_async_fifo.tcl

### DIFF
--- a/syn/vivado/axis_async_fifo.tcl
+++ b/syn/vivado/axis_async_fifo.tcl
@@ -70,7 +70,7 @@ foreach fifo_inst [get_cells -hier -filter {(ORIG_REF_NAME == axis_async_fifo ||
         set_property ASYNC_REG TRUE $sync_ffs
 
         set_max_delay -from [get_cells "$fifo_inst/rd_ptr_reg_reg[*] $fifo_inst/rd_ptr_gray_reg_reg[*]"] -to [get_cells "$fifo_inst/rd_ptr_gray_sync1_reg_reg[*]"] -datapath_only $read_clk_period
-        set_bus_skew  -from [get_cells "$fifo_inst/rd_ptr_reg_reg[*] $fifo_inst/rd_ptr_gray_reg_reg[*]"] -to [get_cells "$fifo_inst/rd_ptr_gray_sync1_reg_reg[*]"] $write_clk_period
+        set_bus_skew  -from [get_cells "$fifo_inst/rd_ptr_reg_reg[*] $fifo_inst/rd_ptr_gray_reg_reg[*]"] -to [get_cells "$fifo_inst/rd_ptr_gray_sync1_reg_reg[*]"] $read_clk_period
     }
 
     set sync_ffs [get_cells -quiet -hier -regexp ".*/wr_ptr_gray_sync\[12\]_reg_reg\\\[\\d+\\\]" -filter "PARENT == $fifo_inst"]
@@ -79,7 +79,7 @@ foreach fifo_inst [get_cells -hier -filter {(ORIG_REF_NAME == axis_async_fifo ||
         set_property ASYNC_REG TRUE $sync_ffs
 
         set_max_delay -from [get_cells -quiet "$fifo_inst/wr_ptr_reg_reg[*] $fifo_inst/wr_ptr_gray_reg_reg[*]"] -to [get_cells "$fifo_inst/wr_ptr_gray_sync1_reg_reg[*]"] -datapath_only $write_clk_period
-        set_bus_skew  -from [get_cells -quiet "$fifo_inst/wr_ptr_reg_reg[*] $fifo_inst/wr_ptr_gray_reg_reg[*]"] -to [get_cells "$fifo_inst/wr_ptr_gray_sync1_reg_reg[*]"] $read_clk_period
+        set_bus_skew  -from [get_cells -quiet "$fifo_inst/wr_ptr_reg_reg[*] $fifo_inst/wr_ptr_gray_reg_reg[*]"] -to [get_cells "$fifo_inst/wr_ptr_gray_sync1_reg_reg[*]"] $write_clk_period
     }
 
     set sync_ffs [get_cells -quiet -hier -regexp ".*/wr_ptr_commit_sync_reg_reg\\\[\\d+\\\]" -filter "PARENT == $fifo_inst"]


### PR DESCRIPTION
The goal of the constraint is to ensure that parallel Gray-coded words sampled in the destination domain always assume valid values. Since Gray code is used, within each **source** clock period, a maximum of one bit can change value. Hence the skew constraint should have an upper bound that is equal to the period of the **source** clock.

This is equivalent to saying that in each destination word, the bits might come from two different source words.

The previous constraint used the destination clock period. This can fail when going from a fast to a slow clock. Imagine going from a 5 ns clock to a 10 ns clock. Words sampled in the destination domain can come from three different source words, meaning that multiple bits might have changed value, meaning that the Gray code might not be valid.

There is a third `set_bus_skew` constraint for the `wr_ptr_commit_sync_reg` signal. This does not seem to use Gray code. So I don't really know what this is. I'm leaving this as it is, maybe someone with more insight into the design can decide what to do with this.